### PR TITLE
Use package:// for mesh paths instead of an absolute build directory

### DIFF
--- a/indy_description/urdf_files/dual_icon3.urdf
+++ b/indy_description/urdf_files/dual_icon3.urdf
@@ -51,14 +51,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/dual_icon3/visual/Body_base.stl"/>
+        <mesh filename="package://indy_description/meshes/dual_icon3/visual/Body_base.stl"/>
       </geometry>
       <material name="icon_grey"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/dual_icon3/collision/Body_base.stl"/>
+        <mesh filename="package://indy_description/meshes/dual_icon3/collision/Body_base.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -71,14 +71,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/dual_icon3/visual/Body_frame.stl"/>
+        <mesh filename="package://indy_description/meshes/dual_icon3/visual/Body_frame.stl"/>
       </geometry>
       <material name="icon_grey"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/dual_icon3/collision/Body_frame.stl"/>
+        <mesh filename="package://indy_description/meshes/dual_icon3/collision/Body_frame.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -91,14 +91,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/dual_icon3/visual/Body_cover.stl"/>
+        <mesh filename="package://indy_description/meshes/dual_icon3/visual/Body_cover.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/dual_icon3/collision/Body_cover.stl"/>
+        <mesh filename="package://indy_description/meshes/dual_icon3/collision/Body_cover.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -111,14 +111,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/visual/ICoN3_0.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/visual/ICoN3_0.stl"/>
       </geometry>
       <material name="icon_grey"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/collision/ICoN3_0.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/collision/ICoN3_0.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -131,14 +131,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/visual/ICoN3_1.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/visual/ICoN3_1.stl"/>
       </geometry>
       <material name="icon_green"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/collision/ICoN3_1.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/collision/ICoN3_1.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -151,14 +151,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/visual/ICoN3_2.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/visual/ICoN3_2.stl"/>
       </geometry>
       <material name="icon_green"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/collision/ICoN3_2.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/collision/ICoN3_2.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -171,14 +171,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/visual/ICoN3_3.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/visual/ICoN3_3.stl"/>
       </geometry>
       <material name="icon_green"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/collision/ICoN3_3.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/collision/ICoN3_3.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -191,14 +191,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/visual/ICoN3_4.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/visual/ICoN3_4.stl"/>
       </geometry>
       <material name="icon_green"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/collision/ICoN3_4.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/collision/ICoN3_4.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -211,14 +211,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/visual/ICoN3_5.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/visual/ICoN3_5.stl"/>
       </geometry>
       <material name="icon_grey"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/collision/ICoN3_5.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/collision/ICoN3_5.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -231,14 +231,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/visual/ICoN3_6.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/visual/ICoN3_6.stl"/>
       </geometry>
       <material name="icon_grey"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/collision/ICoN3_6.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/collision/ICoN3_6.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -251,14 +251,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/visual/ICoN3_0.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/visual/ICoN3_0.stl"/>
       </geometry>
       <material name="icon_grey"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/collision/ICoN3_0.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/collision/ICoN3_0.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -271,14 +271,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/visual/ICoN3_1.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/visual/ICoN3_1.stl"/>
       </geometry>
       <material name="icon_green"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/collision/ICoN3_1.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/collision/ICoN3_1.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -291,14 +291,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/visual/ICoN3_2.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/visual/ICoN3_2.stl"/>
       </geometry>
       <material name="icon_green"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/collision/ICoN3_2.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/collision/ICoN3_2.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -311,14 +311,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/visual/ICoN3_3.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/visual/ICoN3_3.stl"/>
       </geometry>
       <material name="icon_green"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/collision/ICoN3_3.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/collision/ICoN3_3.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -331,14 +331,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/visual/ICoN3_4.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/visual/ICoN3_4.stl"/>
       </geometry>
       <material name="icon_green"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/collision/ICoN3_4.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/collision/ICoN3_4.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -351,14 +351,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/visual/ICoN3_5.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/visual/ICoN3_5.stl"/>
       </geometry>
       <material name="icon_grey"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/collision/ICoN3_5.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/collision/ICoN3_5.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -371,14 +371,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/visual/ICoN3_6.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/visual/ICoN3_6.stl"/>
       </geometry>
       <material name="icon_grey"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/collision/ICoN3_6.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/collision/ICoN3_6.stl"/>
       </geometry>
     </collision>
     <inertial>

--- a/indy_description/urdf_files/eir.urdf
+++ b/indy_description/urdf_files/eir.urdf
@@ -56,14 +56,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="-0.0093 0 0.995"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/base_link.glb" scale="1 1 1"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/base_link.glb" scale="1 1 1"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="-0.0093 0 0.995"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/base_link.STL" scale="1 1 1"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/base_link.STL" scale="1 1 1"/>
       </geometry>
     </collision>
     <inertial>
@@ -76,14 +76,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/link_1.STL" scale="1 1 1"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/link_1.STL" scale="1 1 1"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/link_1.STL" scale="1 1 1"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/link_1.STL" scale="1 1 1"/>
       </geometry>
     </collision>
     <inertial>
@@ -96,14 +96,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/link_2.STL" scale="1 1 1"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/link_2.STL" scale="1 1 1"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/link_2.STL" scale="1 1 1"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/link_2.STL" scale="1 1 1"/>
       </geometry>
     </collision>
     <inertial>
@@ -116,14 +116,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/link_3.STL" scale="1 1 1"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/link_3.STL" scale="1 1 1"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/link_3.STL" scale="1 1 1"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/link_3.STL" scale="1 1 1"/>
       </geometry>
     </collision>
     <inertial>
@@ -136,14 +136,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/link_4.STL" scale="1 1 1"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/link_4.STL" scale="1 1 1"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/link_4.STL" scale="1 1 1"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/link_4.STL" scale="1 1 1"/>
       </geometry>
     </collision>
     <inertial>
@@ -156,14 +156,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/AR5-5_07L-W4C4A2_base.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/AR5-5_07L-W4C4A2_base.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/AR5-5_07L-W4C4A2_base.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/AR5-5_07L-W4C4A2_base.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
   </link>
@@ -171,14 +171,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/AR5-5_07L-W4C4A2_link1.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/AR5-5_07L-W4C4A2_link1.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/AR5-5_07L-W4C4A2_link1.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/AR5-5_07L-W4C4A2_link1.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -191,14 +191,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/AR5-5_07L-W4C4A2_link2.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/AR5-5_07L-W4C4A2_link2.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/AR5-5_07L-W4C4A2_link2.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/AR5-5_07L-W4C4A2_link2.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -211,14 +211,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/AR5-5_07L-W4C4A2_link3.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/AR5-5_07L-W4C4A2_link3.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/AR5-5_07L-W4C4A2_link3.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/AR5-5_07L-W4C4A2_link3.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -231,14 +231,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/AR5-5_07L-W4C4A2_link4.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/AR5-5_07L-W4C4A2_link4.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/AR5-5_07L-W4C4A2_link4.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/AR5-5_07L-W4C4A2_link4.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -251,14 +251,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/AR5-5_07L-W4C4A2_link5.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/AR5-5_07L-W4C4A2_link5.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/AR5-5_07L-W4C4A2_link5.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/AR5-5_07L-W4C4A2_link5.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -271,14 +271,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/AR5-5_07L-W4C4A2_link6.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/AR5-5_07L-W4C4A2_link6.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/AR5-5_07L-W4C4A2_link6.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/AR5-5_07L-W4C4A2_link6.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -291,14 +291,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/AR5-5_07L-W4C4A2_link7.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/AR5-5_07L-W4C4A2_link7.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/AR5-5_07L-W4C4A2_link7.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/AR5-5_07L-W4C4A2_link7.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -311,14 +311,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/AR5-5_07R-W4C4A2_base.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/AR5-5_07R-W4C4A2_base.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/AR5-5_07R-W4C4A2_base.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/AR5-5_07R-W4C4A2_base.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
   </link>
@@ -326,14 +326,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/AR5-5_07R-W4C4A2_link1.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/AR5-5_07R-W4C4A2_link1.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/AR5-5_07R-W4C4A2_link1.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/AR5-5_07R-W4C4A2_link1.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -346,14 +346,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/AR5-5_07R-W4C4A2_link2.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/AR5-5_07R-W4C4A2_link2.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/AR5-5_07R-W4C4A2_link2.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/AR5-5_07R-W4C4A2_link2.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -366,14 +366,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/AR5-5_07R-W4C4A2_link3.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/AR5-5_07R-W4C4A2_link3.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/AR5-5_07R-W4C4A2_link3.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/AR5-5_07R-W4C4A2_link3.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -386,14 +386,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/AR5-5_07R-W4C4A2_link4.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/AR5-5_07R-W4C4A2_link4.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/AR5-5_07R-W4C4A2_link4.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/AR5-5_07R-W4C4A2_link4.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -406,14 +406,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/AR5-5_07R-W4C4A2_link5.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/AR5-5_07R-W4C4A2_link5.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/AR5-5_07R-W4C4A2_link5.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/AR5-5_07R-W4C4A2_link5.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -426,14 +426,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/AR5-5_07R-W4C4A2_link6.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/AR5-5_07R-W4C4A2_link6.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/AR5-5_07R-W4C4A2_link6.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/AR5-5_07R-W4C4A2_link6.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -446,14 +446,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/AR5-5_07R-W4C4A2_link7.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/AR5-5_07R-W4C4A2_link7.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/AR5-5_07R-W4C4A2_link7.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/AR5-5_07R-W4C4A2_link7.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>

--- a/indy_description/urdf_files/eir_dh_ag95.urdf
+++ b/indy_description/urdf_files/eir_dh_ag95.urdf
@@ -56,14 +56,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="-0.0093 0 0.995"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/base_link.glb" scale="1 1 1"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/base_link.glb" scale="1 1 1"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="-0.0093 0 0.995"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/base_link.STL" scale="1 1 1"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/base_link.STL" scale="1 1 1"/>
       </geometry>
     </collision>
     <inertial>
@@ -76,14 +76,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/link_1.STL" scale="1 1 1"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/link_1.STL" scale="1 1 1"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/link_1.STL" scale="1 1 1"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/link_1.STL" scale="1 1 1"/>
       </geometry>
     </collision>
     <inertial>
@@ -96,14 +96,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/link_2.STL" scale="1 1 1"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/link_2.STL" scale="1 1 1"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/link_2.STL" scale="1 1 1"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/link_2.STL" scale="1 1 1"/>
       </geometry>
     </collision>
     <inertial>
@@ -116,14 +116,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/link_3.STL" scale="1 1 1"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/link_3.STL" scale="1 1 1"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/link_3.STL" scale="1 1 1"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/link_3.STL" scale="1 1 1"/>
       </geometry>
     </collision>
     <inertial>
@@ -136,14 +136,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/link_4.STL" scale="1 1 1"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/link_4.STL" scale="1 1 1"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/link_4.STL" scale="1 1 1"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/link_4.STL" scale="1 1 1"/>
       </geometry>
     </collision>
     <inertial>
@@ -156,14 +156,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/AR5-5_07L-W4C4A2_base.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/AR5-5_07L-W4C4A2_base.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/AR5-5_07L-W4C4A2_base.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/AR5-5_07L-W4C4A2_base.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
   </link>
@@ -171,14 +171,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/AR5-5_07L-W4C4A2_link1.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/AR5-5_07L-W4C4A2_link1.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/AR5-5_07L-W4C4A2_link1.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/AR5-5_07L-W4C4A2_link1.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -191,14 +191,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/AR5-5_07L-W4C4A2_link2.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/AR5-5_07L-W4C4A2_link2.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/AR5-5_07L-W4C4A2_link2.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/AR5-5_07L-W4C4A2_link2.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -211,14 +211,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/AR5-5_07L-W4C4A2_link3.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/AR5-5_07L-W4C4A2_link3.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/AR5-5_07L-W4C4A2_link3.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/AR5-5_07L-W4C4A2_link3.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -231,14 +231,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/AR5-5_07L-W4C4A2_link4.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/AR5-5_07L-W4C4A2_link4.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/AR5-5_07L-W4C4A2_link4.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/AR5-5_07L-W4C4A2_link4.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -251,14 +251,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/AR5-5_07L-W4C4A2_link5.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/AR5-5_07L-W4C4A2_link5.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/AR5-5_07L-W4C4A2_link5.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/AR5-5_07L-W4C4A2_link5.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -271,14 +271,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/AR5-5_07L-W4C4A2_link6.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/AR5-5_07L-W4C4A2_link6.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/AR5-5_07L-W4C4A2_link6.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/AR5-5_07L-W4C4A2_link6.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -291,14 +291,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/AR5-5_07L-W4C4A2_link7.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/AR5-5_07L-W4C4A2_link7.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/AR5-5_07L-W4C4A2_link7.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/AR5-5_07L-W4C4A2_link7.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -311,14 +311,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/AR5-5_07R-W4C4A2_base.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/AR5-5_07R-W4C4A2_base.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/AR5-5_07R-W4C4A2_base.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/AR5-5_07R-W4C4A2_base.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
   </link>
@@ -326,14 +326,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/AR5-5_07R-W4C4A2_link1.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/AR5-5_07R-W4C4A2_link1.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/AR5-5_07R-W4C4A2_link1.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/AR5-5_07R-W4C4A2_link1.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -346,14 +346,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/AR5-5_07R-W4C4A2_link2.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/AR5-5_07R-W4C4A2_link2.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/AR5-5_07R-W4C4A2_link2.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/AR5-5_07R-W4C4A2_link2.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -366,14 +366,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/AR5-5_07R-W4C4A2_link3.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/AR5-5_07R-W4C4A2_link3.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/AR5-5_07R-W4C4A2_link3.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/AR5-5_07R-W4C4A2_link3.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -386,14 +386,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/AR5-5_07R-W4C4A2_link4.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/AR5-5_07R-W4C4A2_link4.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/AR5-5_07R-W4C4A2_link4.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/AR5-5_07R-W4C4A2_link4.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -406,14 +406,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/AR5-5_07R-W4C4A2_link5.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/AR5-5_07R-W4C4A2_link5.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/AR5-5_07R-W4C4A2_link5.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/AR5-5_07R-W4C4A2_link5.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -426,14 +426,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/AR5-5_07R-W4C4A2_link6.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/AR5-5_07R-W4C4A2_link6.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/AR5-5_07R-W4C4A2_link6.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/AR5-5_07R-W4C4A2_link6.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -446,14 +446,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/AR5-5_07R-W4C4A2_link7.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/AR5-5_07R-W4C4A2_link7.stl" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/AR5-5_07R-W4C4A2_link7.stl" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/AR5-5_07R-W4C4A2_link7.stl" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -604,14 +604,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/gripper_base_link.glb" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/gripper_base_link.glb" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/gripper_base_link.STL" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/gripper_base_link.STL" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -624,14 +624,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/gripper_crank_Link.glb" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/gripper_crank_Link.glb" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/gripper_crank_Link.STL" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/gripper_crank_Link.STL" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -644,14 +644,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/gripper_crank_Link.glb" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/gripper_crank_Link.glb" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/gripper_crank_Link.STL" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/gripper_crank_Link.STL" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -664,14 +664,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/gripper_rod_link.glb" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/gripper_rod_link.glb" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/gripper_rod_link.STL" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/gripper_rod_link.STL" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -684,14 +684,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/gripper_rod_link.glb" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/gripper_rod_link.glb" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/gripper_rod_link.STL" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/gripper_rod_link.STL" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -704,14 +704,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/gripper_proximal_phalanx_Link.glb" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/gripper_proximal_phalanx_Link.glb" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/gripper_proximal_phalanx_Link.STL" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/gripper_proximal_phalanx_Link.STL" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -724,14 +724,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/gripper_proximal_phalanx_Link.glb" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/gripper_proximal_phalanx_Link.glb" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/gripper_proximal_phalanx_Link.STL" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/gripper_proximal_phalanx_Link.STL" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -744,14 +744,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/gripper_distal_phalanx_Link.glb" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/gripper_distal_phalanx_Link.glb" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/gripper_distal_phalanx_Link.STL" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/gripper_distal_phalanx_Link.STL" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -764,14 +764,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/gripper_distal_phalanx_Link.glb" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/gripper_distal_phalanx_Link.glb" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/gripper_distal_phalanx_Link.STL" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/gripper_distal_phalanx_Link.STL" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -786,14 +786,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/gripper_base_link.glb" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/gripper_base_link.glb" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/gripper_base_link.STL" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/gripper_base_link.STL" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -806,14 +806,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/gripper_crank_Link.glb" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/gripper_crank_Link.glb" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/gripper_crank_Link.STL" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/gripper_crank_Link.STL" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -826,14 +826,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/gripper_crank_Link.glb" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/gripper_crank_Link.glb" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/gripper_crank_Link.STL" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/gripper_crank_Link.STL" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -846,14 +846,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/gripper_rod_link.glb" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/gripper_rod_link.glb" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/gripper_rod_link.STL" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/gripper_rod_link.STL" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -866,14 +866,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/gripper_rod_link.glb" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/gripper_rod_link.glb" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/gripper_rod_link.STL" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/gripper_rod_link.STL" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -886,14 +886,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/gripper_proximal_phalanx_Link.glb" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/gripper_proximal_phalanx_Link.glb" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/gripper_proximal_phalanx_Link.STL" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/gripper_proximal_phalanx_Link.STL" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -906,14 +906,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/gripper_proximal_phalanx_Link.glb" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/gripper_proximal_phalanx_Link.glb" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/gripper_proximal_phalanx_Link.STL" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/gripper_proximal_phalanx_Link.STL" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -926,14 +926,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/gripper_distal_phalanx_Link.glb" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/gripper_distal_phalanx_Link.glb" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/gripper_distal_phalanx_Link.STL" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/gripper_distal_phalanx_Link.STL" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>
@@ -946,14 +946,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/visual/gripper_distal_phalanx_Link.glb" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/visual/gripper_distal_phalanx_Link.glb" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/eir/collision/gripper_distal_phalanx_Link.STL" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://indy_description/meshes/eir/collision/gripper_distal_phalanx_Link.STL" scale="0.001 0.001 0.001"/>
       </geometry>
     </collision>
     <inertial>

--- a/indy_description/urdf_files/icon3.urdf
+++ b/indy_description/urdf_files/icon3.urdf
@@ -51,14 +51,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/visual/ICoN3_0.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/visual/ICoN3_0.stl"/>
       </geometry>
       <material name="icon_grey"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/collision/ICoN3_0.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/collision/ICoN3_0.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -71,14 +71,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/visual/ICoN3_1.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/visual/ICoN3_1.stl"/>
       </geometry>
       <material name="icon_green"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/collision/ICoN3_1.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/collision/ICoN3_1.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -91,14 +91,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/visual/ICoN3_2.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/visual/ICoN3_2.stl"/>
       </geometry>
       <material name="icon_green"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/collision/ICoN3_2.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/collision/ICoN3_2.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -111,14 +111,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/visual/ICoN3_3.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/visual/ICoN3_3.stl"/>
       </geometry>
       <material name="icon_green"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/collision/ICoN3_3.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/collision/ICoN3_3.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -131,14 +131,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/visual/ICoN3_4.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/visual/ICoN3_4.stl"/>
       </geometry>
       <material name="icon_green"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/collision/ICoN3_4.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/collision/ICoN3_4.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -151,14 +151,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/visual/ICoN3_5.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/visual/ICoN3_5.stl"/>
       </geometry>
       <material name="icon_grey"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/collision/ICoN3_5.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/collision/ICoN3_5.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -171,14 +171,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/visual/ICoN3_6.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/visual/ICoN3_6.stl"/>
       </geometry>
       <material name="icon_grey"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon3/collision/ICoN3_6.stl"/>
+        <mesh filename="package://indy_description/meshes/icon3/collision/ICoN3_6.stl"/>
       </geometry>
     </collision>
     <inertial>

--- a/indy_description/urdf_files/icon7l.urdf
+++ b/indy_description/urdf_files/icon7l.urdf
@@ -51,14 +51,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon7l/visual/ICoN7L_0.stl"/>
+        <mesh filename="package://indy_description/meshes/icon7l/visual/ICoN7L_0.stl"/>
       </geometry>
       <material name="icon_grey"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon7l/collision/ICoN7L_0.stl"/>
+        <mesh filename="package://indy_description/meshes/icon7l/collision/ICoN7L_0.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -71,14 +71,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon7l/visual/ICoN7L_1.stl"/>
+        <mesh filename="package://indy_description/meshes/icon7l/visual/ICoN7L_1.stl"/>
       </geometry>
       <material name="icon_green"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon7l/collision/ICoN7L_1.stl"/>
+        <mesh filename="package://indy_description/meshes/icon7l/collision/ICoN7L_1.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -91,14 +91,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon7l/visual/ICoN7L_2.stl"/>
+        <mesh filename="package://indy_description/meshes/icon7l/visual/ICoN7L_2.stl"/>
       </geometry>
       <material name="icon_green"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon7l/collision/ICoN7L_2.stl"/>
+        <mesh filename="package://indy_description/meshes/icon7l/collision/ICoN7L_2.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -111,14 +111,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon7l/visual/ICoN7L_3.stl"/>
+        <mesh filename="package://indy_description/meshes/icon7l/visual/ICoN7L_3.stl"/>
       </geometry>
       <material name="icon_green"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon7l/collision/ICoN7L_3.stl"/>
+        <mesh filename="package://indy_description/meshes/icon7l/collision/ICoN7L_3.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -131,14 +131,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon7l/visual/ICoN7L_4.stl"/>
+        <mesh filename="package://indy_description/meshes/icon7l/visual/ICoN7L_4.stl"/>
       </geometry>
       <material name="icon_green"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon7l/collision/ICoN7L_4.stl"/>
+        <mesh filename="package://indy_description/meshes/icon7l/collision/ICoN7L_4.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -151,14 +151,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon7l/visual/ICoN7L_5.stl"/>
+        <mesh filename="package://indy_description/meshes/icon7l/visual/ICoN7L_5.stl"/>
       </geometry>
       <material name="icon_grey"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon7l/collision/ICoN7L_5.stl"/>
+        <mesh filename="package://indy_description/meshes/icon7l/collision/ICoN7L_5.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -171,14 +171,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon7l/visual/ICoN7L_6.stl"/>
+        <mesh filename="package://indy_description/meshes/icon7l/visual/ICoN7L_6.stl"/>
       </geometry>
       <material name="icon_grey"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/icon7l/collision/ICoN7L_6.stl"/>
+        <mesh filename="package://indy_description/meshes/icon7l/collision/ICoN7L_6.stl"/>
       </geometry>
     </collision>
     <inertial>

--- a/indy_description/urdf_files/indy12.urdf
+++ b/indy_description/urdf_files/indy12.urdf
@@ -51,14 +51,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12/visual/Indy12_0.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12/visual/Indy12_0.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12/collision/Indy12_0.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12/collision/Indy12_0.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -71,14 +71,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12/visual/Indy12_1.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12/visual/Indy12_1.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12/collision/Indy12_1.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12/collision/Indy12_1.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -91,14 +91,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12/visual/Indy12_2.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12/visual/Indy12_2.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12/collision/Indy12_2.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12/collision/Indy12_2.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -111,14 +111,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12/visual/Indy12_3.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12/visual/Indy12_3.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12/collision/Indy12_3.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12/collision/Indy12_3.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -131,14 +131,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12/visual/Indy12_4.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12/visual/Indy12_4.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12/collision/Indy12_4.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12/collision/Indy12_4.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -151,14 +151,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12/visual/Indy12_5.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12/visual/Indy12_5.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12/collision/Indy12_5.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12/collision/Indy12_5.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -171,14 +171,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12/visual/Indy12_6.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12/visual/Indy12_6.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12/collision/Indy12_6.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12/collision/Indy12_6.stl"/>
       </geometry>
     </collision>
     <inertial>

--- a/indy_description/urdf_files/indy12_v2.urdf
+++ b/indy_description/urdf_files/indy12_v2.urdf
@@ -51,14 +51,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v2/visual/Indy12_v2_0.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v2/visual/Indy12_v2_0.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v2/collision/Indy12_v2_0.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v2/collision/Indy12_v2_0.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -71,14 +71,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v2/visual/Indy12_v2_1.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v2/visual/Indy12_v2_1.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v2/collision/Indy12_v2_1.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v2/collision/Indy12_v2_1.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -91,14 +91,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v2/visual/Indy12_v2_2.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v2/visual/Indy12_v2_2.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v2/collision/Indy12_v2_2.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v2/collision/Indy12_v2_2.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -111,14 +111,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v2/visual/Indy12_v2_3.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v2/visual/Indy12_v2_3.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v2/collision/Indy12_v2_3.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v2/collision/Indy12_v2_3.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -131,14 +131,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v2/visual/Indy12_v2_4.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v2/visual/Indy12_v2_4.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v2/collision/Indy12_v2_4.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v2/collision/Indy12_v2_4.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -151,14 +151,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v2/visual/Indy12_v2_5.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v2/visual/Indy12_v2_5.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v2/collision/Indy12_v2_5.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v2/collision/Indy12_v2_5.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -171,14 +171,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v2/visual/Indy12_v2_6.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v2/visual/Indy12_v2_6.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v2/collision/Indy12_v2_6.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v2/collision/Indy12_v2_6.stl"/>
       </geometry>
     </collision>
     <inertial>

--- a/indy_description/urdf_files/indy12_v3.urdf
+++ b/indy_description/urdf_files/indy12_v3.urdf
@@ -51,14 +51,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v3/visual/Indy12_v3_0.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v3/visual/Indy12_v3_0.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v3/collision/Indy12_v3_0.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v3/collision/Indy12_v3_0.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -71,14 +71,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 -0.082"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v3/visual/Indy12_v3_1.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v3/visual/Indy12_v3_1.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 -0.082"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v3/collision/Indy12_v3_1.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v3/collision/Indy12_v3_1.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -91,14 +91,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0.136 -0.350"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v3/visual/Indy12_v3_2.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v3/visual/Indy12_v3_2.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0.136 -0.350"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v3/collision/Indy12_v3_2.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v3/collision/Indy12_v3_2.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -111,14 +111,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0.116 -1.000"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v3/visual/Indy12_v3_3.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v3/visual/Indy12_v3_3.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0.116 -1.000"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v3/collision/Indy12_v3_3.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v3/collision/Indy12_v3_3.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -131,14 +131,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0.009 -1.187"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v3/visual/Indy12_v3_4.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v3/visual/Indy12_v3_4.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0.009 -1.187"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v3/collision/Indy12_v3_4.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v3/collision/Indy12_v3_4.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -151,14 +151,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0.116 -1.550"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v3/visual/Indy12_v3_5.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v3/visual/Indy12_v3_5.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0.116 -1.550"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v3/collision/Indy12_v3_5.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v3/collision/Indy12_v3_5.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -171,14 +171,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0.218 -1.636"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v3/visual/Indy12_v3_6.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v3/visual/Indy12_v3_6.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0.218 -1.636"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v3/collision/Indy12_v3_6.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v3/collision/Indy12_v3_6.stl"/>
       </geometry>
     </collision>
     <inertial>

--- a/indy_description/urdf_files/indy12_v3_eye.urdf
+++ b/indy_description/urdf_files/indy12_v3_eye.urdf
@@ -51,14 +51,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v3/visual/Indy12_v3_0.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v3/visual/Indy12_v3_0.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v3/collision/Indy12_v3_0.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v3/collision/Indy12_v3_0.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -71,14 +71,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 -0.082"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v3/visual/Indy12_v3_1.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v3/visual/Indy12_v3_1.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 -0.082"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v3/collision/Indy12_v3_1.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v3/collision/Indy12_v3_1.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -91,14 +91,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0.136 -0.350"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v3/visual/Indy12_v3_2.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v3/visual/Indy12_v3_2.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0.136 -0.350"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v3/collision/Indy12_v3_2.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v3/collision/Indy12_v3_2.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -111,14 +111,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0.116 -1.000"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v3/visual/Indy12_v3_3.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v3/visual/Indy12_v3_3.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0.116 -1.000"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v3/collision/Indy12_v3_3.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v3/collision/Indy12_v3_3.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -131,14 +131,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0.009 -1.187"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v3/visual/Indy12_v3_4.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v3/visual/Indy12_v3_4.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0.009 -1.187"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v3/collision/Indy12_v3_4.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v3/collision/Indy12_v3_4.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -151,14 +151,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0.116 -1.550"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v3/visual/Indy12_v3_5.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v3/visual/Indy12_v3_5.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0.116 -1.550"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v3/collision/Indy12_v3_5.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v3/collision/Indy12_v3_5.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -171,14 +171,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v3/visual/Indy12_v3_eye_6.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v3/visual/Indy12_v3_eye_6.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy12_v3/collision/Indy12_v3_eye_6.stl"/>
+        <mesh filename="package://indy_description/meshes/indy12_v3/collision/Indy12_v3_eye_6.stl"/>
       </geometry>
     </collision>
     <inertial>

--- a/indy_description/urdf_files/indy7.urdf
+++ b/indy_description/urdf_files/indy7.urdf
@@ -51,14 +51,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7/visual/Indy7_0.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7/visual/Indy7_0.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7/collision/Indy7_0.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7/collision/Indy7_0.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -71,14 +71,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7/visual/Indy7_1.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7/visual/Indy7_1.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7/collision/Indy7_1.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7/collision/Indy7_1.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -91,14 +91,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7/visual/Indy7_2.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7/visual/Indy7_2.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7/collision/Indy7_2.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7/collision/Indy7_2.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -111,14 +111,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7/visual/Indy7_3.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7/visual/Indy7_3.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7/collision/Indy7_3.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7/collision/Indy7_3.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -131,14 +131,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7/visual/Indy7_4.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7/visual/Indy7_4.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7/collision/Indy7_4.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7/collision/Indy7_4.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -151,14 +151,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7/visual/Indy7_5.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7/visual/Indy7_5.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7/collision/Indy7_5.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7/collision/Indy7_5.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -171,14 +171,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7/visual/Indy7_6.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7/visual/Indy7_6.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7/collision/Indy7_6.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7/collision/Indy7_6.stl"/>
       </geometry>
     </collision>
     <inertial>

--- a/indy_description/urdf_files/indy7_eye.urdf
+++ b/indy_description/urdf_files/indy7_eye.urdf
@@ -51,14 +51,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7/visual/Indy7_0.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7/visual/Indy7_0.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7/collision/Indy7_0.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7/collision/Indy7_0.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -71,14 +71,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7/visual/Indy7_1.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7/visual/Indy7_1.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7/collision/Indy7_1.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7/collision/Indy7_1.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -91,14 +91,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7/visual/Indy7_2.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7/visual/Indy7_2.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7/collision/Indy7_2.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7/collision/Indy7_2.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -111,14 +111,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7/visual/Indy7_3.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7/visual/Indy7_3.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7/collision/Indy7_3.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7/collision/Indy7_3.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -131,14 +131,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7/visual/Indy7_4.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7/visual/Indy7_4.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7/collision/Indy7_4.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7/collision/Indy7_4.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -151,14 +151,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7/visual/Indy7_5.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7/visual/Indy7_5.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7/collision/Indy7_5.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7/collision/Indy7_5.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -171,14 +171,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7/visual/Indy7_eye_6.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7/visual/Indy7_eye_6.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7/collision/Indy7_eye_6.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7/collision/Indy7_eye_6.stl"/>
       </geometry>
     </collision>
     <inertial>

--- a/indy_description/urdf_files/indy7_v2.urdf
+++ b/indy_description/urdf_files/indy7_v2.urdf
@@ -51,14 +51,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v2/visual/Indy7_v2_0.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v2/visual/Indy7_v2_0.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v2/collision/Indy7_v2_0.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v2/collision/Indy7_v2_0.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -71,14 +71,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v2/visual/Indy7_v2_1.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v2/visual/Indy7_v2_1.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v2/collision/Indy7_v2_1.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v2/collision/Indy7_v2_1.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -91,14 +91,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v2/visual/Indy7_v2_2.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v2/visual/Indy7_v2_2.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v2/collision/Indy7_v2_2.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v2/collision/Indy7_v2_2.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -111,14 +111,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v2/visual/Indy7_v2_3.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v2/visual/Indy7_v2_3.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v2/collision/Indy7_v2_3.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v2/collision/Indy7_v2_3.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -131,14 +131,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v2/visual/Indy7_v2_4.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v2/visual/Indy7_v2_4.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v2/collision/Indy7_v2_4.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v2/collision/Indy7_v2_4.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -151,14 +151,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v2/visual/Indy7_v2_5.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v2/visual/Indy7_v2_5.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v2/collision/Indy7_v2_5.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v2/collision/Indy7_v2_5.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -171,14 +171,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v2/visual/Indy7_v2_6.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v2/visual/Indy7_v2_6.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v2/collision/Indy7_v2_6.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v2/collision/Indy7_v2_6.stl"/>
       </geometry>
     </collision>
     <inertial>

--- a/indy_description/urdf_files/indy7_v3.urdf
+++ b/indy_description/urdf_files/indy7_v3.urdf
@@ -51,14 +51,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v3/visual/Indy7_v3_0.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v3/visual/Indy7_v3_0.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v3/collision/Indy7_v3_0.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v3/collision/Indy7_v3_0.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -71,14 +71,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v3/visual/Indy7_v3_1.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v3/visual/Indy7_v3_1.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v3/collision/Indy7_v3_1.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v3/collision/Indy7_v3_1.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -91,14 +91,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v3/visual/Indy7_v3_2.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v3/visual/Indy7_v3_2.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v3/collision/Indy7_v3_2.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v3/collision/Indy7_v3_2.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -111,14 +111,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v3/visual/Indy7_v3_3.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v3/visual/Indy7_v3_3.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v3/collision/Indy7_v3_3.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v3/collision/Indy7_v3_3.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -131,14 +131,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v3/visual/Indy7_v3_4.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v3/visual/Indy7_v3_4.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v3/collision/Indy7_v3_4.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v3/collision/Indy7_v3_4.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -151,14 +151,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v3/visual/Indy7_v3_5.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v3/visual/Indy7_v3_5.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v3/collision/Indy7_v3_5.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v3/collision/Indy7_v3_5.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -171,14 +171,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v3/visual/Indy7_v3_6.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v3/visual/Indy7_v3_6.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v3/collision/Indy7_v3_6.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v3/collision/Indy7_v3_6.stl"/>
       </geometry>
     </collision>
     <inertial>

--- a/indy_description/urdf_files/indy7_v3_eye.urdf
+++ b/indy_description/urdf_files/indy7_v3_eye.urdf
@@ -51,14 +51,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v3/visual/Indy7_v3_0.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v3/visual/Indy7_v3_0.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v3/collision/Indy7_v3_0.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v3/collision/Indy7_v3_0.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -71,14 +71,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v3/visual/Indy7_v3_1.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v3/visual/Indy7_v3_1.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v3/collision/Indy7_v3_1.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v3/collision/Indy7_v3_1.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -91,14 +91,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v3/visual/Indy7_v3_2.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v3/visual/Indy7_v3_2.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v3/collision/Indy7_v3_2.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v3/collision/Indy7_v3_2.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -111,14 +111,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v3/visual/Indy7_v3_3.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v3/visual/Indy7_v3_3.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v3/collision/Indy7_v3_3.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v3/collision/Indy7_v3_3.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -131,14 +131,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v3/visual/Indy7_v3_4.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v3/visual/Indy7_v3_4.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v3/collision/Indy7_v3_4.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v3/collision/Indy7_v3_4.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -151,14 +151,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v3/visual/Indy7_v3_5.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v3/visual/Indy7_v3_5.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v3/collision/Indy7_v3_5.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v3/collision/Indy7_v3_5.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -171,14 +171,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v3/visual/Indy7_v3_eye_6.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v3/visual/Indy7_v3_eye_6.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indy7_v3/collision/Indy7_v3_eye_6.stl"/>
+        <mesh filename="package://indy_description/meshes/indy7_v3/collision/Indy7_v3_eye_6.stl"/>
       </geometry>
     </collision>
     <inertial>

--- a/indy_description/urdf_files/indyrp2.urdf
+++ b/indy_description/urdf_files/indyrp2.urdf
@@ -51,14 +51,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2/visual/IndyRP2_0.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2/visual/IndyRP2_0.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2/collision/IndyRP2_0.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2/collision/IndyRP2_0.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -71,14 +71,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2/visual/IndyRP2_1.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2/visual/IndyRP2_1.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2/collision/IndyRP2_1.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2/collision/IndyRP2_1.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -91,14 +91,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2/visual/IndyRP2_2.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2/visual/IndyRP2_2.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2/collision/IndyRP2_2.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2/collision/IndyRP2_2.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -111,14 +111,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2/visual/IndyRP2_3.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2/visual/IndyRP2_3.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2/collision/IndyRP2_3.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2/collision/IndyRP2_3.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -131,14 +131,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2/visual/IndyRP2_4.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2/visual/IndyRP2_4.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2/collision/IndyRP2_4.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2/collision/IndyRP2_4.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -151,14 +151,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2/visual/IndyRP2_5.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2/visual/IndyRP2_5.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2/collision/IndyRP2_5.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2/collision/IndyRP2_5.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -171,14 +171,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2/visual/IndyRP2_6.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2/visual/IndyRP2_6.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2/collision/IndyRP2_6.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2/collision/IndyRP2_6.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -191,14 +191,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2/visual/IndyRP2_7.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2/visual/IndyRP2_7.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2/collision/IndyRP2_7.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2/collision/IndyRP2_7.stl"/>
       </geometry>
     </collision>
     <inertial>

--- a/indy_description/urdf_files/indyrp2_eye.urdf
+++ b/indy_description/urdf_files/indyrp2_eye.urdf
@@ -51,14 +51,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2/visual/IndyRP2_0.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2/visual/IndyRP2_0.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2/collision/IndyRP2_0.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2/collision/IndyRP2_0.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -71,14 +71,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2/visual/IndyRP2_1.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2/visual/IndyRP2_1.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2/collision/IndyRP2_1.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2/collision/IndyRP2_1.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -91,14 +91,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2/visual/IndyRP2_2.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2/visual/IndyRP2_2.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2/collision/IndyRP2_2.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2/collision/IndyRP2_2.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -111,14 +111,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2/visual/IndyRP2_3.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2/visual/IndyRP2_3.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2/collision/IndyRP2_3.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2/collision/IndyRP2_3.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -131,14 +131,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2/visual/IndyRP2_4.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2/visual/IndyRP2_4.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2/collision/IndyRP2_4.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2/collision/IndyRP2_4.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -151,14 +151,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2/visual/IndyRP2_5.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2/visual/IndyRP2_5.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2/collision/IndyRP2_5.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2/collision/IndyRP2_5.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -171,14 +171,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2/visual/IndyRP2_6.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2/visual/IndyRP2_6.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2/collision/IndyRP2_6.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2/collision/IndyRP2_6.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -191,14 +191,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2/visual/IndyRP2_eye_7.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2/visual/IndyRP2_eye_7.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2/collision/IndyRP2_eye_7.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2/collision/IndyRP2_eye_7.stl"/>
       </geometry>
     </collision>
     <inertial>

--- a/indy_description/urdf_files/indyrp2_v2.urdf
+++ b/indy_description/urdf_files/indyrp2_v2.urdf
@@ -51,14 +51,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2_v2/visual/IndyRP2_v2_0.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2_v2/visual/IndyRP2_v2_0.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2_v2/collision/IndyRP2_v2_0.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2_v2/collision/IndyRP2_v2_0.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -71,14 +71,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2_v2/visual/IndyRP2_v2_1.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2_v2/visual/IndyRP2_v2_1.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2_v2/collision/IndyRP2_v2_1.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2_v2/collision/IndyRP2_v2_1.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -91,14 +91,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2_v2/visual/IndyRP2_v2_2.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2_v2/visual/IndyRP2_v2_2.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2_v2/collision/IndyRP2_v2_2.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2_v2/collision/IndyRP2_v2_2.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -111,14 +111,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2_v2/visual/IndyRP2_v2_3.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2_v2/visual/IndyRP2_v2_3.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2_v2/collision/IndyRP2_v2_3.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2_v2/collision/IndyRP2_v2_3.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -131,14 +131,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2_v2/visual/IndyRP2_v2_4.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2_v2/visual/IndyRP2_v2_4.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2_v2/collision/IndyRP2_v2_4.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2_v2/collision/IndyRP2_v2_4.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -151,14 +151,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2_v2/visual/IndyRP2_v2_5.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2_v2/visual/IndyRP2_v2_5.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2_v2/collision/IndyRP2_v2_5.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2_v2/collision/IndyRP2_v2_5.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -171,14 +171,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2_v2/visual/IndyRP2_v2_6.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2_v2/visual/IndyRP2_v2_6.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2_v2/collision/IndyRP2_v2_6.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2_v2/collision/IndyRP2_v2_6.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -191,14 +191,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2_v2/visual/IndyRP2_v2_7.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2_v2/visual/IndyRP2_v2_7.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2_v2/collision/IndyRP2_v2_7.stl"/>
+        <mesh filename="package://indy_description/meshes/indyrp2_v2/collision/IndyRP2_v2_7.stl"/>
       </geometry>
     </collision>
     <inertial>

--- a/indy_description/urdf_files/nuri12c.urdf
+++ b/indy_description/urdf_files/nuri12c.urdf
@@ -51,14 +51,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri12c/visual/Nuri12c_0.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri12c/visual/Nuri12c_0.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri12c/collision/Nuri12c_0.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri12c/collision/Nuri12c_0.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -71,14 +71,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 -0.061"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri12c/visual/Nuri12c_1.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri12c/visual/Nuri12c_1.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 -0.061"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri12c/collision/Nuri12c_1.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri12c/collision/Nuri12c_1.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -91,14 +91,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0.10 -0.286"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri12c/visual/Nuri12c_2.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri12c/visual/Nuri12c_2.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0.10 -0.286"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri12c/collision/Nuri12c_2.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri12c/collision/Nuri12c_2.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -111,14 +111,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0.10 -1.046"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri12c/visual/Nuri12c_3.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri12c/visual/Nuri12c_3.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0.10 -1.046"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri12c/collision/Nuri12c_3.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri12c/collision/Nuri12c_3.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -131,14 +131,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 -1.252"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri12c/visual/Nuri12c_4.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri12c/visual/Nuri12c_4.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 -1.252"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri12c/collision/Nuri12c_4.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri12c/collision/Nuri12c_4.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -151,14 +151,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 -0.079 -1.586"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri12c/visual/Nuri12c_5.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri12c/visual/Nuri12c_5.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 -0.079 -1.586"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri12c/collision/Nuri12c_5.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri12c/collision/Nuri12c_5.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -171,14 +171,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 -0.150 -1.665"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri12c/visual/Nuri12c_6.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri12c/visual/Nuri12c_6.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 -0.150 -1.665"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri12c/collision/Nuri12c_6.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri12c/collision/Nuri12c_6.stl"/>
       </geometry>
     </collision>
     <inertial>

--- a/indy_description/urdf_files/nuri20c.urdf
+++ b/indy_description/urdf_files/nuri20c.urdf
@@ -51,14 +51,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri20c/visual/Nuri20c_0.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri20c/visual/Nuri20c_0.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri20c/collision/Nuri20c_0.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri20c/collision/Nuri20c_0.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -71,14 +71,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri20c/visual/Nuri20c_1.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri20c/visual/Nuri20c_1.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri20c/collision/Nuri20c_1.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri20c/collision/Nuri20c_1.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -91,14 +91,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri20c/visual/Nuri20c_2.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri20c/visual/Nuri20c_2.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri20c/collision/Nuri20c_2.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri20c/collision/Nuri20c_2.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -111,14 +111,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri20c/visual/Nuri20c_3.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri20c/visual/Nuri20c_3.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri20c/collision/Nuri20c_3.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri20c/collision/Nuri20c_3.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -131,14 +131,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri20c/visual/Nuri20c_4.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri20c/visual/Nuri20c_4.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri20c/collision/Nuri20c_4.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri20c/collision/Nuri20c_4.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -151,14 +151,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri20c/visual/Nuri20c_5.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri20c/visual/Nuri20c_5.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri20c/collision/Nuri20c_5.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri20c/collision/Nuri20c_5.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -171,14 +171,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri20c/visual/Nuri20c_6.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri20c/visual/Nuri20c_6.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri20c/collision/Nuri20c_6.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri20c/collision/Nuri20c_6.stl"/>
       </geometry>
     </collision>
     <inertial>

--- a/indy_description/urdf_files/nuri30.urdf
+++ b/indy_description/urdf_files/nuri30.urdf
@@ -51,14 +51,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri30/visual/Nuri30_0.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri30/visual/Nuri30_0.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri30/collision/Nuri30_0.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri30/collision/Nuri30_0.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -71,14 +71,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri30/visual/Nuri30_1.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri30/visual/Nuri30_1.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri30/collision/Nuri30_1.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri30/collision/Nuri30_1.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -91,14 +91,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri30/visual/Nuri30_2.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri30/visual/Nuri30_2.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri30/collision/Nuri30_2.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri30/collision/Nuri30_2.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -111,14 +111,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri30/visual/Nuri30_3.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri30/visual/Nuri30_3.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri30/collision/Nuri30_3.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri30/collision/Nuri30_3.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -131,14 +131,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri30/visual/Nuri30_4.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri30/visual/Nuri30_4.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri30/collision/Nuri30_4.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri30/collision/Nuri30_4.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -151,14 +151,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri30/visual/Nuri30_5.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri30/visual/Nuri30_5.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri30/collision/Nuri30_5.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri30/collision/Nuri30_5.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -171,14 +171,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri30/visual/Nuri30_6.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri30/visual/Nuri30_6.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri30/collision/Nuri30_6.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri30/collision/Nuri30_6.stl"/>
       </geometry>
     </collision>
     <inertial>

--- a/indy_description/urdf_files/nuri3s.urdf
+++ b/indy_description/urdf_files/nuri3s.urdf
@@ -51,14 +51,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri3s/visual/Nuri3s_0.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri3s/visual/Nuri3s_0.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri3s/collision/Nuri3s_0.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri3s/collision/Nuri3s_0.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -71,14 +71,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri3s/visual/Nuri3s_1.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri3s/visual/Nuri3s_1.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri3s/collision/Nuri3s_1.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri3s/collision/Nuri3s_1.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -91,14 +91,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri3s/visual/Nuri3s_2.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri3s/visual/Nuri3s_2.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri3s/collision/Nuri3s_2.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri3s/collision/Nuri3s_2.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -111,14 +111,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri3s/visual/Nuri3s_3.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri3s/visual/Nuri3s_3.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri3s/collision/Nuri3s_3.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri3s/collision/Nuri3s_3.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -131,14 +131,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri3s/visual/Nuri3s_4.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri3s/visual/Nuri3s_4.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri3s/collision/Nuri3s_4.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri3s/collision/Nuri3s_4.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -151,14 +151,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri3s/visual/Nuri3s_5.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri3s/visual/Nuri3s_5.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri3s/collision/Nuri3s_5.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri3s/collision/Nuri3s_5.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -171,14 +171,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri3s/visual/Nuri3s_6.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri3s/visual/Nuri3s_6.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri3s/collision/Nuri3s_6.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri3s/collision/Nuri3s_6.stl"/>
       </geometry>
     </collision>
     <inertial>

--- a/indy_description/urdf_files/nuri4s.urdf
+++ b/indy_description/urdf_files/nuri4s.urdf
@@ -51,14 +51,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/visual/Nuri4s_0.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/visual/Nuri4s_0.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/collision/Nuri4s_0.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/collision/Nuri4s_0.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -71,14 +71,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/visual/Nuri4s_1.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/visual/Nuri4s_1.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/collision/Nuri4s_1.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/collision/Nuri4s_1.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -91,14 +91,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/visual/Nuri4s_2.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/visual/Nuri4s_2.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/collision/Nuri4s_2.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/collision/Nuri4s_2.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -111,14 +111,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/visual/Nuri4s_3.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/visual/Nuri4s_3.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/collision/Nuri4s_3.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/collision/Nuri4s_3.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -131,14 +131,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/visual/Nuri4s_4.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/visual/Nuri4s_4.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/collision/Nuri4s_4.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/collision/Nuri4s_4.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -151,14 +151,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/visual/Nuri4s_5.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/visual/Nuri4s_5.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/collision/Nuri4s_5.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/collision/Nuri4s_5.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -171,14 +171,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/visual/Nuri4s_6.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/visual/Nuri4s_6.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/collision/Nuri4s_6.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/collision/Nuri4s_6.stl"/>
       </geometry>
     </collision>
     <inertial>

--- a/indy_description/urdf_files/nuri5s.urdf
+++ b/indy_description/urdf_files/nuri5s.urdf
@@ -51,14 +51,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/visual/Nuri4s_0.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/visual/Nuri4s_0.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/collision/Nuri4s_0.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/collision/Nuri4s_0.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -71,14 +71,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/visual/Nuri4s_1.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/visual/Nuri4s_1.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/collision/Nuri4s_1.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/collision/Nuri4s_1.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -91,14 +91,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/visual/Nuri4s_2.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/visual/Nuri4s_2.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/collision/Nuri4s_2.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/collision/Nuri4s_2.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -111,14 +111,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/visual/Nuri4s_3.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/visual/Nuri4s_3.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/collision/Nuri4s_3.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/collision/Nuri4s_3.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -131,14 +131,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/visual/Nuri4s_4.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/visual/Nuri4s_4.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/collision/Nuri4s_4.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/collision/Nuri4s_4.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -151,14 +151,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/visual/Nuri4s_5.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/visual/Nuri4s_5.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/collision/Nuri4s_5.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/collision/Nuri4s_5.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -171,14 +171,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/visual/Nuri4s_6.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/visual/Nuri4s_6.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/collision/Nuri4s_6.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/collision/Nuri4s_6.stl"/>
       </geometry>
     </collision>
     <inertial>

--- a/indy_description/urdf_files/nuri5sdual.urdf
+++ b/indy_description/urdf_files/nuri5sdual.urdf
@@ -51,14 +51,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri5sdual/visual/Nuri5sdual_base.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri5sdual/visual/Nuri5sdual_base.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri5sdual/collision/Nuri5sdual_base.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri5sdual/collision/Nuri5sdual_base.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -71,14 +71,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/visual/Nuri4s_0.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/visual/Nuri4s_0.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/collision/Nuri4s_0.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/collision/Nuri4s_0.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -91,14 +91,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/visual/Nuri4s_1.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/visual/Nuri4s_1.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/collision/Nuri4s_1.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/collision/Nuri4s_1.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -111,14 +111,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/visual/Nuri4s_2.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/visual/Nuri4s_2.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/collision/Nuri4s_2.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/collision/Nuri4s_2.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -131,14 +131,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/visual/Nuri4s_3.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/visual/Nuri4s_3.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/collision/Nuri4s_3.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/collision/Nuri4s_3.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -151,14 +151,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/visual/Nuri4s_4.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/visual/Nuri4s_4.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/collision/Nuri4s_4.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/collision/Nuri4s_4.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -171,14 +171,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/visual/Nuri4s_5.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/visual/Nuri4s_5.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/collision/Nuri4s_5.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/collision/Nuri4s_5.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -191,14 +191,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/visual/Nuri4s_6.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/visual/Nuri4s_6.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/collision/Nuri4s_6.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/collision/Nuri4s_6.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -211,14 +211,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/visual/Nuri4s_0.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/visual/Nuri4s_0.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/collision/Nuri4s_0.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/collision/Nuri4s_0.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -231,14 +231,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/visual/Nuri4s_1.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/visual/Nuri4s_1.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/collision/Nuri4s_1.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/collision/Nuri4s_1.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -251,14 +251,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/visual/Nuri4s_2.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/visual/Nuri4s_2.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/collision/Nuri4s_2.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/collision/Nuri4s_2.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -271,14 +271,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/visual/Nuri4s_3.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/visual/Nuri4s_3.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/collision/Nuri4s_3.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/collision/Nuri4s_3.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -291,14 +291,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/visual/Nuri4s_4.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/visual/Nuri4s_4.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/collision/Nuri4s_4.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/collision/Nuri4s_4.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -311,14 +311,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/visual/Nuri4s_5.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/visual/Nuri4s_5.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/collision/Nuri4s_5.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/collision/Nuri4s_5.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -331,14 +331,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/visual/Nuri4s_6.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/visual/Nuri4s_6.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri4s/collision/Nuri4s_6.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri4s/collision/Nuri4s_6.stl"/>
       </geometry>
     </collision>
     <inertial>

--- a/indy_description/urdf_files/nuri7c.urdf
+++ b/indy_description/urdf_files/nuri7c.urdf
@@ -51,14 +51,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri7c/visual/Nuri7c_0.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri7c/visual/Nuri7c_0.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri7c/collision/Nuri7c_0.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri7c/collision/Nuri7c_0.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -71,14 +71,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri7c/visual/Nuri7c_1.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri7c/visual/Nuri7c_1.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri7c/collision/Nuri7c_1.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri7c/collision/Nuri7c_1.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -91,14 +91,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri7c/visual/Nuri7c_2.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri7c/visual/Nuri7c_2.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri7c/collision/Nuri7c_2.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri7c/collision/Nuri7c_2.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -111,14 +111,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri7c/visual/Nuri7c_3.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri7c/visual/Nuri7c_3.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri7c/collision/Nuri7c_3.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri7c/collision/Nuri7c_3.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -131,14 +131,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri7c/visual/Nuri7c_4.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri7c/visual/Nuri7c_4.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri7c/collision/Nuri7c_4.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri7c/collision/Nuri7c_4.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -151,14 +151,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri7c/visual/Nuri7c_5.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri7c/visual/Nuri7c_5.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri7c/collision/Nuri7c_5.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri7c/collision/Nuri7c_5.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -171,14 +171,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri7c/visual/Nuri7c_6.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri7c/visual/Nuri7c_6.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/nuri7c/collision/Nuri7c_6.stl"/>
+        <mesh filename="package://indy_description/meshes/nuri7c/collision/Nuri7c_6.stl"/>
       </geometry>
     </collision>
     <inertial>

--- a/indy_description/urdf_files/opti3.urdf
+++ b/indy_description/urdf_files/opti3.urdf
@@ -51,14 +51,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/opti3/visual/Opti3_0.stl"/>
+        <mesh filename="package://indy_description/meshes/opti3/visual/Opti3_0.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/opti3/collision/Opti3_0.stl"/>
+        <mesh filename="package://indy_description/meshes/opti3/collision/Opti3_0.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -71,14 +71,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/opti3/visual/Opti3_1.stl"/>
+        <mesh filename="package://indy_description/meshes/opti3/visual/Opti3_1.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/opti3/collision/Opti3_1.stl"/>
+        <mesh filename="package://indy_description/meshes/opti3/collision/Opti3_1.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -91,14 +91,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/opti3/visual/Opti3_2.stl"/>
+        <mesh filename="package://indy_description/meshes/opti3/visual/Opti3_2.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/opti3/collision/Opti3_2.stl"/>
+        <mesh filename="package://indy_description/meshes/opti3/collision/Opti3_2.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -111,14 +111,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/opti3/visual/Opti3_3.stl"/>
+        <mesh filename="package://indy_description/meshes/opti3/visual/Opti3_3.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/opti3/collision/Opti3_3.stl"/>
+        <mesh filename="package://indy_description/meshes/opti3/collision/Opti3_3.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -131,14 +131,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/opti3/visual/Opti3_4.stl"/>
+        <mesh filename="package://indy_description/meshes/opti3/visual/Opti3_4.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/opti3/collision/Opti3_4.stl"/>
+        <mesh filename="package://indy_description/meshes/opti3/collision/Opti3_4.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -151,14 +151,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/opti3/visual/Opti3_5.stl"/>
+        <mesh filename="package://indy_description/meshes/opti3/visual/Opti3_5.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/opti3/collision/Opti3_5.stl"/>
+        <mesh filename="package://indy_description/meshes/opti3/collision/Opti3_5.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -171,14 +171,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/opti3/visual/Opti3_6.stl"/>
+        <mesh filename="package://indy_description/meshes/opti3/visual/Opti3_6.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/opti3/collision/Opti3_6.stl"/>
+        <mesh filename="package://indy_description/meshes/opti3/collision/Opti3_6.stl"/>
       </geometry>
     </collision>
     <inertial>

--- a/indy_description/urdf_files/opti5.urdf
+++ b/indy_description/urdf_files/opti5.urdf
@@ -51,14 +51,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/opti5/visual/Opti5_0.stl"/>
+        <mesh filename="package://indy_description/meshes/opti5/visual/Opti5_0.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/opti5/collision/Opti5_0.stl"/>
+        <mesh filename="package://indy_description/meshes/opti5/collision/Opti5_0.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -71,14 +71,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/opti5/visual/Opti5_1.stl"/>
+        <mesh filename="package://indy_description/meshes/opti5/visual/Opti5_1.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/opti5/collision/Opti5_1.stl"/>
+        <mesh filename="package://indy_description/meshes/opti5/collision/Opti5_1.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -91,14 +91,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/opti5/visual/Opti5_2.stl"/>
+        <mesh filename="package://indy_description/meshes/opti5/visual/Opti5_2.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/opti5/collision/Opti5_2.stl"/>
+        <mesh filename="package://indy_description/meshes/opti5/collision/Opti5_2.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -111,14 +111,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/opti5/visual/Opti5_3.stl"/>
+        <mesh filename="package://indy_description/meshes/opti5/visual/Opti5_3.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/opti5/collision/Opti5_3.stl"/>
+        <mesh filename="package://indy_description/meshes/opti5/collision/Opti5_3.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -131,14 +131,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/opti5/visual/Opti5_4.stl"/>
+        <mesh filename="package://indy_description/meshes/opti5/visual/Opti5_4.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/opti5/collision/Opti5_4.stl"/>
+        <mesh filename="package://indy_description/meshes/opti5/collision/Opti5_4.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -151,14 +151,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/opti5/visual/Opti5_5.stl"/>
+        <mesh filename="package://indy_description/meshes/opti5/visual/Opti5_5.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/opti5/collision/Opti5_5.stl"/>
+        <mesh filename="package://indy_description/meshes/opti5/collision/Opti5_5.stl"/>
       </geometry>
     </collision>
     <inertial>
@@ -171,14 +171,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/opti5/visual/Opti5_6.stl"/>
+        <mesh filename="package://indy_description/meshes/opti5/visual/Opti5_6.stl"/>
       </geometry>
       <material name="indy_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/opti5/collision/Opti5_6.stl"/>
+        <mesh filename="package://indy_description/meshes/opti5/collision/Opti5_6.stl"/>
       </geometry>
     </collision>
     <inertial>


### PR DESCRIPTION
Every mesh reference in `indy_description` currently points into a developer's own build tree:

```
file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2_v2/visual/IndyRP2_v2_0.stl
```

That resolves only on a machine where a user named `user` built the package at exactly that path, so as published the descriptions do not load anywhere else. Loading `indyrp2_v2.urdf` fails with:

```
Error opening file 'file:///home/user/indy-ros2/install/indy_description/share/indy_description/meshes/indyrp2_v2/collision/IndyRP2_v2_0.stl'
```

This replaces them with the package-relative form, which is what the meshes' actual location supports:

```
package://indy_description/meshes/indyrp2_v2/visual/IndyRP2_v2_0.stl
```

### Scope

- **27 files, 512 references**, across `urdf_files/` and `urdf/`
- Affects every model in the package, not just one: `indyrp2`, `indyrp2_v2`, `indy7_v2`, `indy12_v3`, `nuri7c`, `opti5` and the rest
- **Paths only.** No geometry, kinematics, inertias, joint limits or materials are touched — the diff is 512 insertions against 512 deletions

### Verification

- All 512 new paths resolved against `indy_description/` on disk: every referenced mesh exists
- The `indyrp2_v2` description now loads in MuJoCo, which reads URDF directly

I have **not** built the workspace with colcon or opened the models in RViz, so this is verified by path resolution and a non-ROS consumer rather than end-to-end in ROS.

### Context

This is likely part of the answer to #8, where a user asks how to convert an Indy model to MuJoCo XML — MuJoCo imports the URDF as-is once the mesh paths resolve.